### PR TITLE
Avoid polluting browser history

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,8 @@ body_class: speaker
     var looks = document.querySelectorAll("#looks a");
     for (var i = 0; i < looks.length; i++) {
         looks[i].addEventListener('click', function(event) {
+            // Avoid polluting the browser history
+            event.preventDefault();
             var image = this.getAttribute('href').replace('#', '');
             document.getElementsByTagName('body')[0].id = image;
         });


### PR DESCRIPTION
I found your site through your recent blog post (https://juokaz.com/blog/becoming-a-cto) and it bugged me that after I clicked through the awesome pictures, I had to press the back button for every picture I cycled through. This fixes it by not adding the link to the browser's history so you only need to press back once.

Admittedly, there is a better way of doing this and it would be to use `window.history.replaceState` but this fix was shorter and didn't entail re-architected the site. 
